### PR TITLE
Bump i18n max to 1.7 (exclusive)

### DIFF
--- a/modis.gemspec
+++ b/modis.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel', '>= 4.2'
   gem.add_runtime_dependency 'activesupport', '>= 4.2'
-  gem.add_runtime_dependency 'i18n', ['>= 0.7', '< 1.3']
   gem.add_runtime_dependency 'redis', '>= 3.0'
   gem.add_runtime_dependency 'hiredis', '>= 0.5'
   gem.add_runtime_dependency 'connection_pool', '>= 2'


### PR DESCRIPTION
https://github.com/rpush/modis/pull/20 restricted the i18n version to < 1.3. I'd like to upgrade i18n in our project but this gem is holding it back at 1.2.x. I just ran specs on jruby-9.2.5.0 and i18n 1.6.0 and they're green. Pending CI results, can we bump to < 1.7?