### PR TITLE
Add missing `#update` and `#update!` persistance methods

### DIFF
--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -158,15 +158,21 @@ module Modis
       save(validate: false)
     end
 
-    def update_attributes(attrs)
+    def update(attrs)
       assign_attributes(attrs)
       save
     end
 
-    def update_attributes!(attrs)
+    alias update_attributes update
+    deprecate update_attributes: 'please, use update instead'
+
+    def update!(attrs)
       assign_attributes(attrs)
       save!
     end
+
+    alias update_attributes! update!
+    deprecate update_attributes!: 'please, use update! instead'
 
     private
 

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -249,6 +249,33 @@ describe Modis::Persistence do
     end
   end
 
+  describe 'update!' do
+    it 'updates the given attributes' do
+      model.update!(name: 'Derp', age: 29)
+      model.reload
+      expect(model.name).to eq 'Derp'
+      expect(model.age).to eq 29
+    end
+
+    it 'invokes callbacks' do
+      model.update!(name: 'Derp')
+      expect(model.called_callbacks).to_not be_empty
+    end
+
+    it 'updates all dirty attributes' do
+      model.age = 29
+      model.update!(name: 'Derp')
+      model.reload
+      expect(model.age).to eq 29
+    end
+
+    it 'raises an error if the model is invalid' do
+      expect do
+        model.update!(name: nil).to be false
+      end.to raise_error(Modis::RecordInvalid)
+    end
+  end
+
   describe 'update_attributes!' do
     it 'updates the given attributes' do
       model.update_attributes!(name: 'Derp', age: 29)
@@ -273,6 +300,31 @@ describe Modis::Persistence do
       expect do
         model.update_attributes!(name: nil).to be false
       end.to raise_error(Modis::RecordInvalid)
+    end
+  end
+
+  describe 'update' do
+    it 'updates the given attributes' do
+      model.update(name: 'Derp', age: 29)
+      model.reload
+      expect(model.name).to eq('Derp')
+      expect(model.age).to eq(29)
+    end
+
+    it 'invokes callbacks' do
+      model.update(name: 'Derp')
+      expect(model.called_callbacks).to_not be_empty
+    end
+
+    it 'updates all dirty attributes' do
+      model.age = 29
+      model.update(name: 'Derp')
+      model.reload
+      expect(model.age).to eq(29)
+    end
+
+    it 'returns false if the model is invalid' do
+      expect(model.update(name: nil)).to be false
     end
   end
 


### PR DESCRIPTION
When trying to fix some deprecation warning in **Rpush** - https://github.com/rpush/rpush/pull/541, we realized that we are not following the same API than ActiveRecord.

At the moment we are just supporting `#update_attributes` and `#update_attributes!` to update records. Those methods have been aliased in ActiveRecord for years, and finally will be removed in the next version - Rails 6.1.

To don't break the current API, we are aliasing the deprecated methods with the new naming, and adding a warning that explains the replacement.