### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,14 +12,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.1)
-      activesupport (= 6.0.1)
-    activesupport (6.0.1)
+    activemodel (6.0.3.2)
+      activesupport (= 6.0.3.2)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     appraisal (2.2.0)
       bundler
       rake
@@ -29,16 +29,16 @@ GEM
       parallel
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     diff-lcs (1.3)
     docile (1.1.5)
     hiredis (0.6.3)
-    i18n (1.7.0)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.0)
-    minitest (5.13.0)
+    minitest (5.14.1)
     msgpack (1.3.1)
     parallel (1.19.1)
     parser (2.6.5.0)
@@ -76,10 +76,10 @@ GEM
     simplecov-html (0.10.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
-    zeitwerk (2.2.2)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/benchmark/persistence.rb
+++ b/benchmark/persistence.rb
@@ -62,7 +62,7 @@ Bench.run do |b|
   b.report(:update_without_changes) do
     user = create_user
     n.times do
-      user.update_attributes!(name: user.name, age: user.age)
+      user.update!(name: user.name, age: user.age)
     end
   end
 

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -185,7 +185,7 @@ module Modis
       validate(args)
       future = persist
 
-      if future && (future == :unchanged || future.value == 'OK')
+      if future && (:unchanged == future || future.value == 'OK')
         changes_applied
         @new_record = false
         true

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -185,7 +185,7 @@ module Modis
       validate(args)
       future = persist
 
-      if future && (:unchanged == future || future.value == 'OK')
+      if future && ((future.is_a?(Symbol) && future == :unchanged) || future.value == 'OK')
         changes_applied
         @new_record = false
         true

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -277,6 +277,8 @@ describe Modis::Persistence do
   end
 
   describe 'update_attributes!' do
+    around(:each) { |example| ActiveSupport::Deprecation.silence { example.run } }
+
     it 'updates the given attributes' do
       model.update_attributes!(name: 'Derp', age: 29)
       model.reload
@@ -329,6 +331,8 @@ describe Modis::Persistence do
   end
 
   describe 'update_attributes' do
+    around(:each) { |example| ActiveSupport::Deprecation.silence { example.run } }
+
     it 'updates the given attributes' do
       model.update_attributes(name: 'Derp', age: 29)
       model.reload


### PR DESCRIPTION
I believe this fixes all deprecation warnings when running with:
- latest `redis` gem
- latest `activemodel` gem
- latest Ruby (2.7.1)

You can reproduce these deprecation warnings by cloning the current repo, changing `.ruby-version` to `2.7.1`, and running `bundle exec rspec`.

Also replaces #29 (bumping `activesupport` for a security update).