### PR TITLE
Fix deprectated pipeline calls for Redis 4.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.2.1)
+    redis (4.6.0)
     rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -93,4 +93,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.21

--- a/lib/modis/transaction.rb
+++ b/lib/modis/transaction.rb
@@ -8,7 +8,7 @@ module Modis
 
     module ClassMethods
       def transaction
-        Modis.with_connection { |redis| redis.multi { yield(redis) } }
+        Modis.with_connection { |redis| redis.multi { |transaction| yield(transaction) } }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ end
 
 require 'modis'
 
+Redis.raise_deprecations = true if Gem.loaded_specs['redis'].version >= Gem::Version.new('4.6.0')
+
 Modis.configure do |config|
   config.namespace = 'modis'
 end


### PR DESCRIPTION
Redis 4.6.0 deprecates accessing `redis` within pipeline and multi calls. Fix our calls to these methods to use the PipelinedConnection given in the block argument.

This is to pair with the rpush PR https://github.com/rpush/rpush/pull/636

Since the previous versions of redis passed the `Client` object to the block argument, our new calling syntax is compatible with both pre-4.6.0, and post-4.6.0.

I made some decisions here that probably need some feedback from maintainers:

- Upgraded redis in the Gemfile to 4.6.0. We currently only test this single version. Should we use different versions in the CI matrix? I did write the specs to support this, mocking the correct behavior for before/after 4.6.0.
- Turned on Redis 4.6.0 deprecation errors in specs