### PR TITLE
Compatibility with redis 4.7.x gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activesupport (>= 5.2)
       connection_pool (>= 2)
       msgpack (>= 0.5)
-      redis (>= 3.0, < 4.7)
+      redis (>= 3.0, < 4.8)
 
 GEM
   remote: https://rubygems.org/
@@ -43,7 +43,7 @@ GEM
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.6.0)
+    redis (4.7.1)
     rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/modis.gemspec
+++ b/modis.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel', '>= 5.2'
   gem.add_runtime_dependency 'activesupport', '>= 5.2'
-  gem.add_runtime_dependency 'redis', '>= 3.0', '< 4.7'
+  gem.add_runtime_dependency 'redis', '>= 3.0', '< 4.8'
   gem.add_runtime_dependency 'connection_pool', '>= 2'
 
   if defined? JRUBY_VERSION

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -111,13 +111,8 @@ describe Modis::Persistence do
 
   it 'does not track the ID if the underlying Redis command failed' do
     redis = double(hmset: double(value: nil), sadd: nil)
-    if Gem::Version.new(Redis::VERSION) > Gem::Version.new('4.6.0')
-      expect(model.class).to receive(:transaction).and_yield(Redis::PipelinedConnection.new(Redis::Pipeline::Multi.new(redis)))
-      expect(redis).to receive(:pipelined).and_yield(Redis::PipelinedConnection.new(Redis::Pipeline.new(redis)))
-    else
-      expect(model.class).to receive(:transaction).and_yield(redis)
-      expect(redis).to receive(:pipelined).and_yield(redis)
-    end
+    expect(model.class).to receive(:transaction).and_yield(redis)
+    expect(redis).to receive(:pipelined).and_yield(redis)
     model.save
     expect { model.class.find(model.id) }.to raise_error(Modis::RecordNotFound)
   end
@@ -140,13 +135,8 @@ describe Modis::Persistence do
       model.age = 11
       redis = double
       expect(redis).to receive(:hmset).with("modis:persistence_spec:mock_model:1", ["age", "\v"]).and_return(double(value: 'OK'))
-      if Gem::Version.new(Redis::VERSION) > Gem::Version.new('4.6.0')
-        expect(model.class).to receive(:transaction).and_yield(Redis::PipelinedConnection.new(Redis::Pipeline::Multi.new(redis)))
-        expect(redis).to receive(:pipelined).and_yield(Redis::PipelinedConnection.new(Redis::Pipeline.new(redis)))
-      else
-        expect(model.class).to receive(:transaction).and_yield(redis)
-        expect(redis).to receive(:pipelined).and_yield(redis)
-      end
+      expect(model.class).to receive(:transaction).and_yield(redis)
+      expect(redis).to receive(:pipelined).and_yield(redis)
       model.save!
       expect(model.age).to eq(11)
     end


### PR DESCRIPTION
It's not clear why this complexity was added in https://github.com/rpush/modis/pull/32 but it was unnecessary and breaks the test suite with redis 4.7.1. Removing it continues with tests passing on 4.6.0 and fixes the tests with 4.7.1.

Compatibility with redis 4.8.x will come in https://github.com/rpush/modis/pull/35.

See https://github.com/rpush/modis/pull/36.