### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -7,6 +7,7 @@ require 'active_support/all'
 require 'msgpack'
 
 require 'modis/version'
+require 'modis/deprecator'
 require 'modis/configuration'
 require 'modis/attribute'
 require 'modis/errors'

--- a/lib/modis/deprecator.rb
+++ b/lib/modis/deprecator.rb
@@ -1,0 +1,5 @@
+module Modis
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'modis')
+  end
+end

--- a/lib/modis/deprecator.rb
+++ b/lib/modis/deprecator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Modis
   def self.deprecator
     @deprecator ||= ActiveSupport::Deprecation.new('5.0', 'modis')

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -166,7 +166,7 @@ module Modis
     end
 
     alias update_attributes update
-    deprecate update_attributes: 'please, use update instead'
+    deprecate update_attributes: 'please, use update instead', deprecator: Modis.deprecator
 
     def update!(attrs)
       assign_attributes(attrs)
@@ -174,7 +174,7 @@ module Modis
     end
 
     alias update_attributes! update!
-    deprecate update_attributes!: 'please, use update! instead'
+    deprecate update_attributes!: 'please, use update! instead', deprecator: Modis.deprecator
 
     private
 


### PR DESCRIPTION
While working on a new feature for modis (#49) I noticed that calling `deprecate` without passing in a deprecator instance is deprecated. 
Thought I would address this apart from the larger feature PR.