### PR TITLE
Add support for multiple redis connections

### DIFF
--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -18,13 +18,20 @@ require 'modis/model'
 
 module Modis
   @mutex = Mutex.new
-
   class << self
     attr_writer :redis_options, :connection_pool_size, :connection_pool_timeout,
-                :connection_pool
+                :connection_pools
 
     def redis_options
-      @redis_options ||= {}
+      @redis_options ||= { default: {} }
+    end
+
+    def redis_options=(options)
+      if options.is_a?(Hash) && options.values.first.is_a?(Hash)
+        @redis_options = options.transform_values(&:dup)
+      else
+        @redis_options[:default] = options
+      end
     end
 
     def connection_pool_size
@@ -35,17 +42,25 @@ module Modis
       @connection_pool_timeout ||= 5
     end
 
-    def connection_pool
-      return @connection_pool if @connection_pool
+    def connection_pools
+      @connection_pools ||= {}
+    end
 
-      @mutex.synchronize do
-        options = { size: connection_pool_size, timeout: connection_pool_timeout }
-        @connection_pool = ConnectionPool.new(options) { Redis.new(redis_options) }
+    def connection_pool(pool_name = :default)
+      connection_pools[pool_name] ||= begin
+        @mutex.synchronize do
+          ConnectionPool.new(
+            size: connection_pool_size,
+            timeout: connection_pool_timeout
+          ) do
+            Redis.new(redis_options[pool_name])
+          end
+        end
       end
     end
 
-    def with_connection
-      connection_pool.with { |connection| yield(connection) }
+    def with_connection(pool_name = :default)
+      connection_pool(pool_name).with { |connection| yield(connection) }
     end
   end
 end

--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -19,7 +19,7 @@ require 'modis/model'
 module Modis
   @mutex = Mutex.new
   class << self
-    attr_writer :redis_options, :connection_pool_size, :connection_pool_timeout,
+    attr_writer :connection_pool_size, :connection_pool_timeout,
                 :connection_pools
 
     def redis_options

--- a/lib/modis/finder.rb
+++ b/lib/modis/finder.rb
@@ -18,7 +18,7 @@ module Modis
             "because you disabled all index. See :enable_all_index for more."
         end
 
-        records = Modis.with_connection(self.modis_connection) do |redis|
+        records = Modis.with_connection(modis_connection) do |redis|
           ids = redis.smembers(key_for(:all))
           redis.pipelined do |pipeline|
             ids.map { |id| record_for(pipeline, id) }
@@ -41,7 +41,7 @@ module Modis
       def find_all(ids)
         raise RecordNotFound, "Couldn't find #{name} without an ID" if ids.empty?
 
-        records = Modis.with_connection(self.modis_connection) do |redis|
+        records = Modis.with_connection(modis_connection) do |redis|
           if ids.count == 1
             ids.map { |id| record_for(redis, id) }
           else

--- a/lib/modis/finder.rb
+++ b/lib/modis/finder.rb
@@ -18,7 +18,7 @@ module Modis
             "because you disabled all index. See :enable_all_index for more."
         end
 
-        records = Modis.with_connection do |redis|
+        records = Modis.with_connection(self.modis_connection) do |redis|
           ids = redis.smembers(key_for(:all))
           redis.pipelined do |pipeline|
             ids.map { |id| record_for(pipeline, id) }
@@ -41,7 +41,7 @@ module Modis
       def find_all(ids)
         raise RecordNotFound, "Couldn't find #{name} without an ID" if ids.empty?
 
-        records = Modis.with_connection do |redis|
+        records = Modis.with_connection(self.modis_connection) do |redis|
           if ids.count == 1
             ids.map { |id| record_for(redis, id) }
           else

--- a/lib/modis/index.rb
+++ b/lib/modis/index.rb
@@ -36,7 +36,7 @@ module Modis
       end
 
       def index_for(attribute, value)
-        Modis.with_connection(self.modis_connection) do |redis|
+        Modis.with_connection(modis_connection) do |redis|
           key = index_key(attribute, value)
           redis.smembers(key).map(&:to_i)
         end

--- a/lib/modis/index.rb
+++ b/lib/modis/index.rb
@@ -36,7 +36,7 @@ module Modis
       end
 
       def index_for(attribute, value)
-        Modis.with_connection do |redis|
+        Modis.with_connection(self.modis_connection) do |redis|
           key = index_key(attribute, value)
           redis.smembers(key).map(&:to_i)
         end

--- a/lib/modis/model.rb
+++ b/lib/modis/model.rb
@@ -21,6 +21,8 @@ module Modis
         include Modis::Index
 
         base.extend(ClassMethods)
+        base.class_attribute :modis_connection
+        base.modis_connection = :default
       end
     end
 

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -150,7 +150,7 @@ module Modis
     end
 
     def reload
-      new_attributes = Modis.with_connection(self.modis_connection) { |redis| self.class.attributes_for(redis, id) }
+      new_attributes = Modis.with_connection(modis_connection) { |redis| self.class.attributes_for(redis, id) }
       initialize(new_attributes)
       self
     end
@@ -253,7 +253,7 @@ module Modis
 
     def set_id
       namespace = self.class.sti_child? ? self.class.sti_base_absolute_namespace : self.class.absolute_namespace
-      Modis.with_connection(self.modis_connection) do |redis|
+      Modis.with_connection(modis_connection) do |redis|
         self.id = redis.incr("#{namespace}_id_seq")
       end
     end

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -150,7 +150,7 @@ module Modis
     end
 
     def reload
-      new_attributes = Modis.with_connection { |redis| self.class.attributes_for(redis, id) }
+      new_attributes = Modis.with_connection(self.modis_connection) { |redis| self.class.attributes_for(redis, id) }
       initialize(new_attributes)
       self
     end
@@ -253,7 +253,7 @@ module Modis
 
     def set_id
       namespace = self.class.sti_child? ? self.class.sti_base_absolute_namespace : self.class.absolute_namespace
-      Modis.with_connection do |redis|
+      Modis.with_connection(self.modis_connection) do |redis|
         self.id = redis.incr("#{namespace}_id_seq")
       end
     end

--- a/lib/modis/transaction.rb
+++ b/lib/modis/transaction.rb
@@ -8,7 +8,7 @@ module Modis
 
     module ClassMethods
       def transaction
-        Modis.with_connection { |redis| redis.multi { |transaction| yield(transaction) } }
+        Modis.with_connection(self.modis_connection) { |redis| redis.multi { |transaction| yield(transaction) } }
       end
     end
   end

--- a/lib/modis/transaction.rb
+++ b/lib/modis/transaction.rb
@@ -8,7 +8,7 @@ module Modis
 
     module ClassMethods
       def transaction
-        Modis.with_connection(self.modis_connection) { |redis| redis.multi { |transaction| yield(transaction) } }
+        Modis.with_connection(modis_connection) { |redis| redis.multi { |transaction| yield(transaction) } }
       end
     end
   end

--- a/spec/multi_redis_spec.rb
+++ b/spec/multi_redis_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module MultiRedisSpec
+  class DefaultUserModel
+    include Modis::Model
+
+    attribute :name, :string
+  end
+
+  class CustomUserModel
+    include Modis::Model
+    self.modis_connection = :custom
+
+    attribute :name, :string
+  end
+end
+
+describe 'Multiple redis support' do
+  before do
+    Modis.redis_options = {
+      default: { url: 'redis://localhost:6379/0' },
+      custom: { url: 'redis://localhost:6379/1' }
+    }
+  end
+
+  it 'uses the default redis connection' do
+    expect(Modis).to receive(:with_connection).with(:default).at_least(3).times.and_call_original
+    user = MultiRedisSpec::DefaultUserModel.create!(name: 'Ian')
+
+    expect(Modis).to receive(:with_connection).with(:default).at_least(3).times.and_call_original
+    MultiRedisSpec::DefaultUserModel.find(user.id)
+  end
+
+  it 'uses the specified redis connection when set up' do
+    expect(Modis).to receive(:with_connection).with(:custom).at_least(3).times.and_call_original
+    user = MultiRedisSpec::CustomUserModel.create!(name: 'Tanya')
+
+    expect(Modis).to receive(:with_connection).with(:custom).at_least(3).times.and_call_original
+    MultiRedisSpec::CustomUserModel.find(user.id)
+  end
+end
+
+describe 'backwards compatibility' do
+   before do
+    Modis.redis_options = {
+      url: 'redis://localhost:6379/0'
+    }
+  end
+
+  it 'uses the default redis connection' do
+    expect(Modis).to receive(:with_connection).with(:default).at_least(3).times.and_call_original
+    MultiRedisSpec::DefaultUserModel.create!(name: 'Ian')
+  end
+end

--- a/spec/multi_redis_spec.rb
+++ b/spec/multi_redis_spec.rb
@@ -41,7 +41,7 @@ describe 'Multiple redis support' do
 end
 
 describe 'backwards compatibility' do
-   before do
+  before do
     Modis.redis_options = {
       url: 'redis://localhost:6379/0'
     }

--- a/spec/multi_redis_spec.rb
+++ b/spec/multi_redis_spec.rb
@@ -9,7 +9,7 @@ module MultiRedisSpec
 
   class CustomUserModel
     include Modis::Model
-    modis_connection = :custom
+    self.modis_connection = :custom
 
     attribute :name, :string
   end

--- a/spec/multi_redis_spec.rb
+++ b/spec/multi_redis_spec.rb
@@ -9,7 +9,7 @@ module MultiRedisSpec
 
   class CustomUserModel
     include Modis::Model
-    self.modis_connection = :custom
+    modis_connection = :custom
 
     attribute :name, :string
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,12 @@ end
 
 RSpec.configure do |config|
   config.after :each do
-    Modis.with_connection do |connection|
-      keys = connection.keys "#{Modis.config.namespace}:*"
-      connection.del(*keys) unless keys.empty?
+    RSpec::Mocks.space.proxy_for(Modis).reset
+    Modis.connection_pools.each do |key, _|
+      Modis.with_connection(key) do |connection|
+        keys = connection.keys "#{Modis.config.namespace}:*"
+        connection.del(*keys) unless keys.empty?
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for more than one redis connection by providing multiple configurations to `redis_options` like this:
```ruby
Modis.redis_options = {
  default: { url: 'redis://localhost:6379/0' },
  custom: { url: 'redis://localhost:6379/1' }
}
```
while still being backwards compatible to the old configuration style
```ruby
Modis.redis_options = {
 url: 'redis://localhost:6379/0
}
```

You can then select which connection to use on a per model basis
```ruby
class User
  include Modis::Model
  self.modis_connection = :custom

  attribute :name, :string
end
```

If you have any ideas on how to improve the tests I am more than happy to change them.